### PR TITLE
add link to license in published version

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,6 +10,6 @@
 					{{ link.name }}</a></li>
 			{% endfor %}
 		</ul>
-		<p class="copyright">&copy; {{ site.title }} {{ site.time | date: "%Y" }}. All rights reserved.</p>
+		<p class="copyright">&copy; {{ site.title }} {{ site.time | date: "%Y" }}. All rights reserved. <a href="https://github.com/armory/knowledge-base/blob/master/LICENSE">License</a></p>
 	</div>
 </footer>


### PR DESCRIPTION
Adds a link to the license on the footer. Ex:
![](https://cl.ly/1G2H2F1T282G/Image%202018-04-17%20at%2016.05.05.png)