### PR TITLE
fix(demo-env): fix demo environment links

### DIFF
--- a/_posts/armory/1200-07-10-demo-environment.md
+++ b/_posts/armory/1200-07-10-demo-environment.md
@@ -7,7 +7,7 @@ description: Armory Spinnaker Demo Environment
 type: Document
 ---
 
-Armory offers [this Demo Environment](http://go.armory.io/demo-environment), letting you explore Armory’s distribution of Spinnaker without having to install it in your environment. You’ll be able to explore the features that Armory adds to provide a robust, enterprise-grade solution. You can learn more about these features & pricing [right here](http://www.armory.io/pricing).
+Armory offers [this Demo Environment](https://spinnaker.demo.armory.io), letting you explore Armory’s distribution of Spinnaker without having to install it in your environment. You’ll be able to explore the features that Armory adds to provide a robust, enterprise-grade solution. You can learn more about these features & pricing [right here](http://www.armory.io/pricing).
 
 You’ll find everything you need to get a feel for how Spinnaker works and see various examples for real-world use cases. The video below will guide you through the demo environment, so you know everything to look for.
 
@@ -18,5 +18,5 @@ When you’re ready to install Armory Spinnaker in your own Kubernetes cluster, 
 ***
 
 ### More Resources: 
-- [Armory Demo Environment](http://go.armory.io/demo-environment)
+- [Armory Demo Environment](https://spinnaker.demo.armory.io)
 - [Demo Pipelines Repo](https://github.com/armory/demo-pipelines)


### PR DESCRIPTION
the short link changed to the kb post so links to the actual demo env
were just going back to the kb post