### PR TITLE
docs(custom-ca): document mounting a keystore

### DIFF
--- a/_posts/admin/2018-12-19-custom-ca.md
+++ b/_posts/admin/2018-12-19-custom-ca.md
@@ -1,0 +1,42 @@
+---
+date: 2018-12-29
+title: Configuring Spinnaker to use internal Certificate Authorities
+categories:
+   - Admin
+description: Configuring Spinnaker to use internal Certificate Authorities
+type: Document
+---
+
+There are a lot of places in Spinnaker which support the ability to configure custom Java trust/key stores for organizations who use internally signed certificates. In some cases, however, this isn't supported yet but you still need to talk to a service which serves one of these certificates. This post will show you how to import your certificate into a Java trust/key store and configure a Spinnaker service with it. 
+
+_This document assumes that you have `kubectl` access to your Kubernetes cluster and are using the latest version of Halyard (either OSS or Armory's extension)._
+
+1. Create a temporary copy of your system's Java trust/key store and import your internal certificate. If you're on a Mac, this will be located at `$(/usr/libexec/java_home/)/jre/lib/security/cacerts`. It will be different on Linux.
+
+```
+$ mkdir /tmp/custom-trust-store
+$ cp {path-to-cacerts} /tmp/custom-trust-store
+$ keytool import -alias custom-ca -keystore /tmp/custom-trust-store/cacerts -file {your-internal-certificate}
+```
+
+2. Use `kubectl` to create a Secret from your copy of `cacerts`.
+
+```
+$ kubectl create secret generic -n {your-spinnaker-namespace} internal-trust-store --from-file /tmp/custom-trust-store/cacerts
+```
+
+3. Configure a Spinnaker service with the new trust/key store using volume mount. In this example we'll be configuring Front50 with this new store.
+
+```
+# ~/.hal/default/service-settings/front50.yml
+kubernetes:
+  volumes:
+  - id: internal-trust-store
+    mountPath: /etc/ssl/certs/java
+    type: secret
+```
+
+4. Redeploy Spinnaker using `hal deploy apply`.
+
+
+The Spinnaker component for which you configured the volume mount should now be using the new trust/key store by default.


### PR DESCRIPTION
document an approach for mounting a custom keystore for a Spinnaker
component