### PR TITLE
fix(security):  Update Nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,13 @@
 source 'https://rubygems.org'
 
 gem 'jekyll', '~> 3.7.2'
+gem 'nokogiri', '~> 1.8.5'
 
 group :jekyll_plugins do
   gem "jekyll-livereload"
-  gem 'jekyll-archives', '2.1.1'
-  gem 'jekyll-extract-element', '0.0.7'
-  gem 'jekyll-feed', '0.9.3'
-  gem 'jekyll-seo-tag', '2.4.0'
-  gem 'jekyll-sitemap', '1.2.0'
+  gem 'jekyll-archives'
+  gem 'jekyll-extract-element', git: 'https://github.com/armory/jekyll-extract-element'
+  gem 'jekyll-feed'
+  gem 'jekyll-seo-tag'
+  gem 'jekyll-sitemap'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,23 @@
+GIT
+  remote: https://github.com/armory/jekyll-extract-element
+  revision: fd8c8f6a6b1bf47cf033bccff5fea1beb48f51f8
+  specs:
+    jekyll-extract-element (0.0.7)
+      jekyll (~> 3.3)
+      nokogiri (~> 1.8.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
-    ffi (1.9.25)
+    ffi (1.11.1)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
@@ -27,44 +35,41 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
-    jekyll-archives (2.1.1)
-      jekyll (>= 2.4)
-    jekyll-extract-element (0.0.7)
-      jekyll (~> 3.3)
-      nokogiri (= 1.8.2)
-    jekyll-feed (0.9.3)
-      jekyll (~> 3.3)
+    jekyll-archives (2.2.1)
+      jekyll (>= 3.6, < 5.0)
+    jekyll-feed (0.12.1)
+      jekyll (>= 3.7, < 5.0)
     jekyll-livereload (0.2.2)
       em-websocket (~> 0.5)
       jekyll (~> 3.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
-    jekyll-seo-tag (2.4.0)
-      jekyll (~> 3.3)
-    jekyll-sitemap (1.2.0)
-      jekyll (~> 3.3)
-    jekyll-watch (2.1.1)
+    jekyll-seo-tag (2.6.1)
+      jekyll (>= 3.3, < 5.0)
+    jekyll-sitemap (1.3.1)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (1.17.0)
-    liquid (4.0.1)
+    liquid (4.0.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     mercenary (0.3.6)
     mini_portile2 (2.3.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    pathutil (0.16.1)
+    pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (3.0.3)
+    public_suffix (4.0.1)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
-    rouge (3.3.0)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
+    rouge (3.9.0)
     ruby_dep (1.5.0)
-    safe_yaml (1.0.4)
-    sass (3.6.0)
+    safe_yaml (1.0.5)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -75,12 +80,13 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 3.7.2)
-  jekyll-archives (= 2.1.1)
-  jekyll-extract-element (= 0.0.7)
-  jekyll-feed (= 0.9.3)
+  jekyll-archives
+  jekyll-extract-element!
+  jekyll-feed
   jekyll-livereload
-  jekyll-seo-tag (= 2.4.0)
-  jekyll-sitemap (= 1.2.0)
+  jekyll-seo-tag
+  jekyll-sitemap
+  nokogiri (~> 1.8.5)
 
 BUNDLED WITH
-   1.16.5
+   1.17.2


### PR DESCRIPTION
Needed to fork the jekyll-extract-element in order to let it use a newer
version of Nokogiri; this Gemfile uses our version for now.  If the PR
gets merged back to master, we can re-point the Gemfile to the original
gem package (which should hopefully be 0.0.8 at that point)